### PR TITLE
Change CR heating term from va.grad(Pc) to -(v+vs).simga(F - v(E+P))

### DIFF
--- a/src/cr/integrators/cr_integrators.cpp
+++ b/src/cr/integrators/cr_integrators.cpp
@@ -43,7 +43,7 @@ CRIntegrator::CRIntegrator(CosmicRay *pcr, ParameterInput *pin) {
   cell_volume_.NewAthenaArray(nthreads,ncells1);
 
   grad_pc_.NewAthenaArray(3,ncells3,ncells2,ncells1);
-
+  ec_source_.NewAthenaArray(ncells3,ncells2,ncells1);
 }
 
 // Destructor
@@ -73,7 +73,7 @@ CRIntegrator::~CRIntegrator()
   cell_volume_.DeleteAthenaArray();
 
   grad_pc_.DeleteAthenaArray();
-
+  ec_source_.DeleteAthenaArray();
 }
 
 void CRIntegrator::RotateVec(const Real sint, const Real cost, 

--- a/src/cr/integrators/cr_integrators.hpp
+++ b/src/cr/integrators/cr_integrators.hpp
@@ -25,7 +25,7 @@ class CRIntegrator {
   void AddSourceTerms(MeshBlock *pmb, const Real dt, AthenaArray<Real> &u,
                       AthenaArray<Real> &w, AthenaArray<Real> &u_cr);
 
-  void CalculateFluxes(MeshBlock *pmb, AthenaArray<Real> &w, 
+  void CalculateFluxes(MeshBlock *pmb, AthenaArray<Real> &w, AthenaArray<Real> &bcc, 
 		       AthenaArray<Real> &u_cr, int reconstruct_order);
 
   void AddFluxDivergenceToAverage(MeshBlock *pmb, AthenaArray<Real> &u_cr,
@@ -96,6 +96,7 @@ class CRIntegrator {
   AthenaArray<Real> vel_l_,vel_r_,wl_,wr_,vdiff_l_,vdiff_r_;
   AthenaArray<Real> eddl_,eddr_;
   AthenaArray<Real> grad_pc_;
+  AthenaArray<Real> ec_source_;
 
   // Temporary array to store the flux
   Real taufact_;

--- a/src/cr/integrators/cr_source.cpp
+++ b/src/cr/integrators/cr_source.cpp
@@ -75,28 +75,16 @@ void CRIntegrator::AddSourceTerms(MeshBlock *pmb, const Real dt, AthenaArray<Rea
         InvRotateVec(sint_b,cost_b,sinp_b,cosp_b,newfr1,newfr2,newfr3);
 
         // Update Cosmic Ray quantities
-	u_cr(CRE ,k,j,i) = ec;
+	u_cr(CRE ,k,j,i) = ec + dt*ec_source_(k,j,i);
         u_cr(CRF1,k,j,i) = newfr1;
         u_cr(CRF2,k,j,i) = newfr2;
         u_cr(CRF3,k,j,i) = newfr3;
 
         // Add source term to gas
-        u(IM1,k,j,i) += (-(newfr1 - fc1) / vmax);
-        u(IM2,k,j,i) += (-(newfr2 - fc2) / vmax);
-        u(IM3,k,j,i) += (-(newfr3 - fc3) / vmax);
-        
-        // Limit the velocity to vlim*vmax
-        Real vx = u(IM1,k,j,i)/u(IDN,k,j,i);
-        Real vy = u(IM2,k,j,i)/u(IDN,k,j,i);
-        Real vz = u(IM3,k,j,i)/u(IDN,k,j,i);
-        Real vel = sqrt(vx*vx + vy*vy + vz*vz);
-        Real ratio = vel/vmax;
-        if (ratio > pcr->vlim) {
-          Real factor = pcr->vlim/ratio;
-          u(IM1,k,j,i) *= factor;
-          u(IM2,k,j,i) *= factor;
-          u(IM3,k,j,i) *= factor;
-        }
+        //u(IEN,k,j,i) -= dt*ec_source_(k,j,i);
+        //u(IM1,k,j,i) += (-(newfr1 - fc1) / vmax);
+        //u(IM2,k,j,i) += (-(newfr2 - fc2) / vmax);
+        //u(IM3,k,j,i) += (-(newfr3 - fc3) / vmax);
 
       }// end i
     }// end j

--- a/src/task_list/time_integrator.cpp
+++ b/src/task_list/time_integrator.cpp
@@ -1002,15 +1002,16 @@ enum TaskStatus TimeIntegratorTaskList::CRFluxes(MeshBlock *pmb, int stage)
 {
   CosmicRay *pcr=pmb->pcr;
   Hydro *phydro=pmb->phydro;
+  Field *pfield=pmb->pfield;
 
   if (stage <= nstages) {
     // why this specific if statement? not needed if pmb->precon->xorder is set to 1
     if((stage == 1) && (integrator == "vl2")) {
-      pcr->pcrintegrator->CalculateFluxes(pmb, phydro->w, pcr->u_cr, 1);
+      pcr->pcrintegrator->CalculateFluxes(pmb, phydro->w, pfield->bcc, pcr->u_cr, 1);
       return TASK_NEXT;
     } else {
       //Note, should make sure that pcrintegrator can handle order of 3, not True as of now
-      pcr->pcrintegrator->CalculateFluxes(pmb, phydro->w, pcr->u_cr, pmb->precon->xorder);
+      pcr->pcrintegrator->CalculateFluxes(pmb, phydro->w, pfield->bcc, pcr->u_cr, pmb->precon->xorder);
       return TASK_NEXT;
     }
   }


### PR DESCRIPTION
 The main change is the
implementation of CR heating term V_A\dot Grad P_c. I change it to
-(V+V_s)\dot \Sigma (F - v(E+P)). They should be identical in the
tightly coupled regime. The reason I made the change is the concern
that V_a\dot Grad P_c may overestimate the heating rate in the loosely
coupled regime. 